### PR TITLE
add ability to select TrueHD stream in container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +690,7 @@ dependencies = [
 name = "mlp"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "clap 3.0.0-beta.1",
  "crc",
  "ffmpeg4-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4.8"
 os_str_bytes = "2.3.1"
 mpls = "0.2.0"
 indicatif = "0.14.0"
+anyhow = "1.0"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ You can download the latest binaries for **macOS** and **Windows** from the [Rel
 
 ## Usage
 
-Demux the TrueHD stream from a given blu-ray playlist file, optionally with the given angle (which starts at 1):
+Demux the TrueHD stream from a given blu-ray playlist file:
 
 ```powershell
-mlp demux playlist "F:\BDMV\PLAYLIST\00800.mpls" --output "out.thd" --angle 2
+mlp demux playlist "F:\BDMV\PLAYLIST\00800.mpls" --output "out.thd"
 ```
 
-Print the segment map and any available angles for the given playlist file:
+Print the available TrueHD streams, the segment map, and any available angles for the given playlist file:
 
 ```powershell
 mlp demux playlist "F:\BDMV\PLAYLIST\00800.mpls"
@@ -38,7 +38,23 @@ mlp info "out.thd"
 mlp info "00055.m2ts"
 ```
 
-All commands support `-v` or `-vv` for more verbose output.
+### Additional arguments
+
+If your blu-ray has multiple angles, you must select one with `--angle <index>`. The given `<index>` starts at 1. This only applies to the `demux playlist` command.
+
+```powershell
+mlp demux playlist "F:\BDMV\PLAYLIST\00800.mpls" --output "out.thd" --angle 2
+```
+
+If the selected container format contains multiple TrueHD streams, you must select one with `--stream <index>`. A list of streams is printed at the start, or you can use `ffprobe <m2ts-file>` or `mlp demux playlist <playlist-file>` to see the available streams and their indices. This applies to all commands.
+
+```powershell
+mlp demux playlist "F:\BDMV\PLAYLIST\00800.mpls" --output "out.thd" --stream 1
+mlp demux segments -s "F:\BDMV\STREAM" -o "out.thd" -l "55,56" --stream 2
+mlp info "00055.m2ts" --stream 3
+```
+
+Every command supports `-v` or `-vv` for more verbose output.
 
 ## FAQ
 

--- a/src/libav/av_error.rs
+++ b/src/libav/av_error.rs
@@ -14,6 +14,7 @@ pub enum DemuxErr {
     NoVideoStreamFound,
     NoTrueHdStreamFound,
     NoTrueHdFramesEncountered,
+    SelectedTrueHdStreamNotFound(i32),
 }
 
 #[derive(Debug)]
@@ -52,14 +53,14 @@ impl Display for AVError {
         match self {
             AVError::IoErr(e) => write!(f, "{}", e),
             AVError::FFMpegErr(i) => write!(f, "ffmpeg error code: {}", i),
-            AVError::DemuxErr(e) => {
-                let msg = match e {
-                    DemuxErr::NoTrueHdStreamFound => "No TrueHD stream found.",
-                    DemuxErr::NoVideoStreamFound => "No video stream found.",
-                    DemuxErr::NoTrueHdFramesEncountered => "No TrueHD frames encountered.",
-                };
-                write!(f, "{}", msg)
-            }
+            AVError::DemuxErr(e) => match e {
+                DemuxErr::NoTrueHdStreamFound => write!(f, "No TrueHD stream found."),
+                DemuxErr::NoVideoStreamFound => write!(f, "No video stream found."),
+                DemuxErr::NoTrueHdFramesEncountered => write!(f, "No TrueHD frames encountered."),
+                DemuxErr::SelectedTrueHdStreamNotFound(i) => {
+                    write!(f, "TrueHD stream with index {} not found.", i)
+                }
+            },
             AVError::OtherErr(e) => {
                 let msg = match e {
                     OtherErr::FilePathIsNotUtf8(path) => {

--- a/src/libav/demux.rs
+++ b/src/libav/demux.rs
@@ -213,11 +213,11 @@ pub fn demux_thd<W: Write + Seek>(
                 // open the current segment and decode only the first TrueHD frame
                 let mut avctx = AVFormatContext::open(&segment.path)?;
                 let streams = avctx.streams()?;
-                let thd_stream = streams
+                let decoded_head_frame = streams
                     .iter()
                     .find(|&s| s.codec.id == ffmpeg4_ffi::sys::AVCodecID_AV_CODEC_ID_TRUEHD)
-                    .unwrap();
-                match decode_head_frame(&mut avctx, thd_stream)? {
+                    .and_then(|thd_stream| decode_head_frame(&mut avctx, thd_stream).ok()?);
+                match decoded_head_frame {
                     Some(decoded_frame) => decoded_frame,
                     None => {
                         warn!(

--- a/src/libav/demux.rs
+++ b/src/libav/demux.rs
@@ -245,7 +245,7 @@ pub fn demux_thd<W: Write + Seek>(
             if n_delete > 0 {
                 // delete the most recently written frame by moving the file
                 // cursor back
-                &out_writer
+                let _ = &out_writer
                     .seek(SeekFrom::Current(-(tail_header.length as i64)))
                     .unwrap();
                 let mut prev_stats = stats.segments.last_mut().unwrap();
@@ -352,7 +352,7 @@ fn write_thd_segment<W: Write + Seek>(
 
             // copy the TrueHD frame to the output
             let pkt_slice = packet.as_slice();
-            &thd_writer.write_all(&pkt_slice)?;
+            let _ = &thd_writer.write_all(&pkt_slice)?;
 
             // push frame header to queue (we want to remember the last
             // n frame headers we saw)

--- a/src/libav/truehd.rs
+++ b/src/libav/truehd.rs
@@ -147,7 +147,7 @@ impl Display for DecodedThdFrame {
 
 impl Display for ThdMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({} Hz, {} ch)", self.sample_rate, self.channels)
+        write!(f, "{} Hz, {} ch", self.sample_rate, self.channels)
     }
 }
 


### PR DESCRIPTION
Fixes #2.

Adds `--stream` argument which allows selecting a particular TrueHD stream if the container (.m2ts, etc) has more than 1 of them.