### PR TITLE
Select stream

### DIFF
--- a/src/libav/demux.rs
+++ b/src/libav/demux.rs
@@ -213,11 +213,11 @@ pub fn demux_thd<W: Write + Seek>(
                 // open the current segment and decode only the first TrueHD frame
                 let mut avctx = AVFormatContext::open(&segment.path)?;
                 let streams = avctx.streams()?;
-                let thd_stream = streams
+                let decoded_head_frame = streams
                     .iter()
                     .find(|&s| s.codec.id == ffmpeg4_ffi::sys::AVCodecID_AV_CODEC_ID_TRUEHD)
-                    .unwrap();
-                match decode_head_frame(&mut avctx, thd_stream)? {
+                    .and_then(|thd_stream| decode_head_frame(&mut avctx, thd_stream).ok()?);
+                match decoded_head_frame {
                     Some(decoded_frame) => decoded_frame,
                     None => {
                         warn!(

--- a/src/libav/demux.rs
+++ b/src/libav/demux.rs
@@ -245,7 +245,7 @@ pub fn demux_thd<W: Write + Seek>(
             if n_delete > 0 {
                 // delete the most recently written frame by moving the file
                 // cursor back
-                &out_writer
+                let _ = &out_writer
                     .seek(SeekFrom::Current(-(tail_header.length as i64)))
                     .unwrap();
                 let mut prev_stats = stats.segments.last_mut().unwrap();
@@ -352,7 +352,7 @@ fn write_thd_segment<W: Write + Seek>(
 
             // copy the TrueHD frame to the output
             let pkt_slice = packet.as_slice();
-            &thd_writer.write_all(&pkt_slice)?;
+            let _ = &thd_writer.write_all(&pkt_slice)?;
 
             // push frame header to queue (we want to remember the last
             // n frame headers we saw)


### PR DESCRIPTION
Closes #15.

- Replaces the `unwrap()` call that causes the panic (when called on an `Option` with value `None`) with an `and_then()` call that calls `decode_head_frame()` and converts the `Result` to an `Option`.
- Fixes two build warnings for `warning: unused borrow that must be used`.
- **Note**: To get this to build, you'll likely need to merge #14 first, and then merge up `master` to the `select-stream` branch before merging this PR

With the above change, I test a few streams and got identical output with these changes, mlp v0.5.0, and DGDemux. So, in the case where the entire TrueHD stream for a given playlist is contained within a single segment, it seems like this is working (and DGDemux may have fixed previous differences in its processing?).